### PR TITLE
Add Telegram bot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Test-Codex
+
+This repository contains a simple Telegram bot example. It responds to the `/about` command by sending the user's first available profile photo along with their first name, last name and Telegram ID.
+
+## Setup
+
+1. Install the required library:
+   ```bash
+   pip install python-telegram-bot
+   ```
+2. Replace the `TOKEN` value in `bot.py` with your bot's token from BotFather.
+
+## Usage
+
+Run the bot with:
+```bash
+python bot.py
+```
+
+Send `/about` to the bot in Telegram to receive your profile information.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,27 @@
+from telegram import Update
+from telegram.ext import Updater, CommandHandler, CallbackContext
+
+TOKEN = "YOUR_BOT_TOKEN_HERE"
+
+def about(update: Update, context: CallbackContext) -> None:
+    user = update.effective_user
+    photos = context.bot.get_user_profile_photos(user.id, limit=1)
+    if photos.total_count > 0:
+        photo_file_id = photos.photos[0][-1].file_id
+        context.bot.send_photo(chat_id=update.effective_chat.id, photo=photo_file_id)
+    text = (
+        f"First name: {user.first_name}\n"
+        f"Last name: {user.last_name}\n"
+        f"Telegram ID: {user.id}"
+    )
+    update.message.reply_text(text)
+
+def main() -> None:
+    updater = Updater(TOKEN)
+    dispatcher = updater.dispatcher
+    dispatcher.add_handler(CommandHandler("about", about))
+    updater.start_polling()
+    updater.idle()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add example Telegram bot script with `/about` command
- document setup and usage in README

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68449843d2ac8325974eb14d6c805355